### PR TITLE
Irma and refs

### DIFF
--- a/assets/IRMA_MODULE/init.sh
+++ b/assets/IRMA_MODULE/init.sh
@@ -1,61 +1,57 @@
 ### PERFORMANCE ###
-GRID_ON=0		# grid computation on [1,0] for on or off
-SINGLE_LOCAL_PROC=16	# local maximum processes
-DOUBLE_LOCAL_PROC=8	# local maximum processes (double this number)
-ALLOW_TMP=0		# if GRID_ON=0, try to use /tmp for working directory
-TMP=/tmp		# the scratch/tmpfs for working on the assemblies
+GRID_ON=0               # grid computation on [1,0] for on or off
+GRID_PATH=""            # grid path, defaults to the IRMA_RES path if left empty string, do not include quotes for tilde prefix
+SINGLE_LOCAL_PROC=16    # local maximum processes
+DOUBLE_LOCAL_PROC=8     # local maximum processes (double this number)
+ALLOW_TMP=1             # if GRID_ON=0, try to use /tmp for working directory
+TMP=/tmp                # the scratch/tmpfs for working on the assemblies
 
 ### REFERENCE ###
-MIN_FA=1		# no alternative reference [0..1]
-MIN_CA=20		# minimum count for alternative finished assembly
-SKIP_E=1		# skip reference elongation
-REF_SET=$DEF_SET	# Same as the "consensus.fasta" in the reference folder for the module.
-ASSEM_REF=0      # start with same reference set for the final assembly, sort if custom file
+MIN_FA=1                # no alternative reference [0..1]
+MIN_CA=20               # minimum count for alternative finished assembly
+SKIP_E=1                # skip reference elongation
+REF_SET=$DEF_SET        # Same as the "consensus.fasta" in the reference folder for the module.
 
 ### READ GATHERING ###
-MAX_ROUNDS=5		# round of read gathering
-USE_MEDIAN=1		# use the median quality or the average [1,0]
-QUAL_THRESHOLD=30	# minimum read statistic
-MIN_LEN=75		# minimum read length
+MAX_ROUNDS=5                    # round of read gathering
+USE_MEDIAN=1                    # use the median quality or the average [1,0]
+QUAL_THRESHOLD=30               # minimum read statistic
+MIN_LEN=125                     # minimum read length
+ENFORCE_CLIPPED_LENGTH=0        # Off. Reads are filtered for minimum length post adapter trimming.
 
 ## MATCH STEP
-MATCH_PROC=20		# grid maximum processes for the MATCH
-MATCH_PROG="BLAT"	# match (all or any match) program [BLAT]
-MIN_RP=15		# minimum read pattern count to continue
-MIN_RC=15		# minimum read count to continue
+MATCH_PROC=20           # grid maximum processes for the MATCH
+MATCH_PROG="BLAT"       # match (all or any match) program [BLAT]
+MIN_RP=15               # minimum read pattern count to continue
+MIN_RC=15               # minimum read count to continue
 
-## SORT STEP 
-SORT_PROG="BLAT"	# [LABEL,BLAT]
-SORT_PROC=80		# currently not used
-NONSEGMENTED=0		# segmented! [0,1]
-# LABEL
-LFASTM=0		# LABEL sorting fast-mode
+## SORT STEP
+SORT_PROG="BLAT"        # [LABEL,BLAT]
+SORT_PROC=80            # currently not used
+NONSEGMENTED=0
 
 ## ALIGN STEP ##
-ALIGN_PROG="BLAT"	# rough assembly / alignment to working reference [SAM,BLAT]
-ALIGN_PROC=20		# grid maximum processes for the rough align
+ALIGN_PROG="SAM"        # rough assembly / alignment to working reference [SAM,BLAT]
+ALIGN_PROC=20           # grid maximum processes for the rough align
 
 ### FINISHING ASSEMBLY ###
-ASSEM_PROG="SSW"	# assembly program [SSW]
-ASSEM_PROC=20		# grid maximum processes for assembly
-INS_T=0.25		# minimum frquenncy threshold for insertion refinement
-DEL_T=0.60		# minimum frequency threshold for deletion refinement 
-MIN_AMBIG=0.25		# minimum called SNV frequency for mixed base in amended consensus folder
-ALIGN_AMENDED=0          # do global alignment of the amended consensus to the HMM profile
-PADDED_CONSENSUS=0      # attempt to pad amended_consensus with Ns for amplicaton dropout: requires ALIGN_AMENDED=1 and ASSEM_REF=1
-MIN_CONS_SUPPORT=1      # consensus allele minimum count, used to amend final consensus as 'N' if support fails. Blank is off.
-MIN_CONS_QUALITY=0      # consensus allele minimum average quality, used to amend final consensus as 'N' if threshold fails. Blank is off.
+ASSEM_PROG="SSW"        # assembly program [SSW]
+ASSEM_PROC=20           # grid maximum processes for assembly
+INS_T=0.25              # minimum frquenncy threshold for insertion refinement
+DEL_T=0.60              # minimum frequency threshold for deletion refinement
+MIN_AMBIG=0.20          # minimum called SNV frequency for mixed base in amended consensus folder
+
 
 ### VARIANT CALLING ###
 # HEURISTICS
-AUTO_F=1		# auto-adjust frequency threshold [1,0]
-MIN_FI=0.005		# minimum insertion variant frequency
-MIN_FD=0.005		# minimum deletion variant frequency
-MIN_F=0.008		# minimum frequency for single nucleotide variants
-MIN_C=2			# minimum count for variants
-MIN_AQ=24		# minimum average variant quality, does not apply to deletions
-MIN_TCC=100		# minimum non-ambiguous column coverage
-MIN_CONF=0.80		# minimum confidence not machine error
+AUTO_F=1                # auto-adjust frequency threshold [1,0]
+MIN_FI=0.005            # minimum insertion variant frequency
+MIN_FD=0.005            # minimum deletion variant frequency
+MIN_F=0.008             # minimum frequency for single nucleotide variants
+MIN_C=2                 # minimum count for variants
+MIN_AQ=24               # minimum average variant quality, does not apply to deletions
+MIN_TCC=100             # minimum non-ambiguous column coverage
+MIN_CONF=0.80           # minimum confidence not machine error
 
 # CONFIDENCE INTERVALS
-SIG_LEVEL=0.999		# significance test level for variant calling (.90,.95,.99,.999). 
+SIG_LEVEL=0.999         # significance test level for variant calling (.90,.95,.99,.999).

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -209,6 +209,17 @@ process {
             ],
         ]
     }
+    withName: 'FINALIZE_REFS' {
+        container = 'public.ecr.aws/o8h2f0o1/vaper-base:1.0'
+        ext.args            = ""
+        ext.when            = {  }
+        publishDir          = [
+            [
+                path: { "${params.outdir}" },
+                pattern: "none"
+            ],
+        ]
+    }
     withName: 'BWA_MEM' {
         ext.args            = ""
         ext.when            = {  }
@@ -246,7 +257,7 @@ process {
         ]
     }
     withName: 'IVAR_CONSENSUS' {
-        ext.args            = ""
+        ext.args            = "-n 'N'"
         ext.when            = {  }
         publishDir = [
             [

--- a/modules/local/finalize-refs.nf
+++ b/modules/local/finalize-refs.nf
@@ -1,0 +1,22 @@
+process FINALIZE_REFS {
+    tag "${ref_id}"
+    label 'process_low'
+
+    input:
+    tuple val(ref_id), path(ref)
+
+    output:
+    tuple val(ref_id), path("*.fa.gz", includeInputs: true), emit: refs
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def cat = ref.name.endsWith('.gz') ? 'zcat' : 'cat'
+    """
+    # Set header to match the file name and concatenate multi-fasta files
+    echo ">${ref_id}" > tmp.fa
+    ${cat} ${ref} | grep -v '>' | tr -d '\n\r\t ' >> tmp.fa
+    cat tmp.fa | gzip > ${ref_id}.fa.gz
+    """
+}

--- a/modules/local/irma.nf
+++ b/modules/local/irma.nf
@@ -6,104 +6,68 @@ process IRMA {
     container "public.ecr.aws/o8h2f0o1/irma:1.1.4"
 
     input:
-    tuple val(meta), path(refs, stageAs: "refs/*"), path(reads)
+    tuple val(meta), val(ref_id), path(ref), path(reads)
     path module_template
 
     output:
-    tuple val(meta), path('*.fa.gz'),          emit: consensus
-    tuple val(meta), path('results/*.bam'),    emit: bam
-    tuple val(meta), path('results/logs/'),    emit: logs
-    tuple val(meta), path('results/figures/'), emit: figures
-    path "versions.yml",                       emit: versions
+    tuple val(meta), val(ref_id), path('*.fa.gz'),          emit: consensus, optional: true
+    tuple val(meta), val(ref_id), path('results/*.bam'),    emit: bam, optional: true
+    tuple val(meta), val(ref_id), path('results/logs/'),    emit: logs
+    tuple val(meta), val(ref_id), path('results/figures/'), emit: figures
+    path "versions.yml",                                    emit: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
     def args = task.ext.args ?: ''
-    prefix = "${meta.id}"
-
+    prefix = "${meta.id}_${ref_id}"
+    assembly_path = params.cons_assembly_type == 'plurality' ?  "results/${ref_id}.fasta" : ( params.cons_assembly_type == 'padded' ? "results/amended_consensus/results-${ref_id}.pad.fa" : "results/amended_consensus/results-${ref_id}.fa" )
     """
-    # copy IRMA to workdir
+    #----- PREPARE IRMA -----#
+    # Copy IRMA to workdir
     irma_path=\$(which IRMA)
     cp -r \${irma_path%IRMA} ./
     irma_path="\$(dirname \${irma_path#/})/IRMA"
 
-    # create module
+    # Create module
     mod=\$(shuf -er -n20  {A..Z} {a..z} {0..9} | tr -d '\n')
     mv ${module_template} \${irma_path}_RES/modules/\${mod}
 
-    # apply config options
-    ## choose an assembly type
-    case "${params.cons_type}" in
-        'plurality')
-            echo 'Returning plurality assembly'
-            assembly_path='results/'
-            assembly_ext=".fasta" 
-            ;;
-        'amended')
-            echo 'Returning amended assembly'
-            assembly_path='results/amended_consensus/results-'
-            assembly_ext=".fa" 
-            ;;
-        'padded')
-            echo -e 'ASSEM_REF=1\nALIGN_AMENDED=1\nPADDED_CONSENSUS=1' >> irma.config
-            assembly_path='results/amended_consensus/results-'
-            assembly_ext=".pad.fa"
-            ;;
-        *)
-            echo "ERROR: '--cons_type' must be 'plurality', 'amended', or 'padded'" && exit 1
-            ;;
-    esac
-    ## set QC thresholds
-    echo -e 'MIN_AMBIG=${params.cons_ratio}\nMIN_CONS_SUPPORT=${params.cons_depth}\nMIN_CONS_QUALITY=${params.cons_qual}\nDEL_TYPE=${ params.cons_drop ? '' : ( params.cons_amb == 'N' ? 'NNN' : params.cons_amb ) }' >> irma.config
-    ## set elongation option
-    echo -e 'SKIP_E=${ params.cons_elong ? '1' : '0' }' >> irma.config
-         
-    # prepare references
-    for REF in \$(ls refs/)
-    do
-        ## concatenate multi-fasta references and change fasta header to match the fasta name
-        ## this mimics the concat step performed by iVar while also allowing for grouping of data in the main workflow
-        echo ">\${REF%%.*}" > \${REF%.gz}
-        zcat refs/\${REF} | grep -v '>' | tr -d '\n\r\t ' >> \${REF%.gz} && echo >> \${REF%.gz}
-        
-        ## create HMM profiles for each reference
-        ls \${irma_path%IRMA}LABEL_RES/scripts/modelfromalign_Linux
-        \${irma_path%IRMA}LABEL_RES/scripts/modelfromalign_Linux \${REF%%.*}_hmm -alignfile \${REF%.gz}
-        mv \${REF%%.*}_hmm.mod \${irma_path}_RES/modules/\${mod}/profiles/
+    #----- CONFIG OPTIONS -----#
+    # Custom parameters
+    echo 'MIN_AMBIG=${params.cons_allele_ratio}' > irma.config
+    echo 'MIN_CONS_SUPPORT=${params.cons_allele_depth}' >> irma.config
+    echo 'MIN_CONS_QUALITY=${params.cons_allele_qual}' >> irma.config
+    echo -e 'SKIP_E=${ params.cons_assembly_elong ? '0' : '1' }' >> irma.config
+    # Padded Assembly
+    if [ "${params.cons_assembly_type}" == 'padded' ]
+    then
+        echo 'ASSEM_REF=1' >> irma.config
+        echo 'ALIGN_AMENDED=1' >> irma.config
+        echo 'PADDED_CONSENSUS=1' >> irma.config
+    fi
 
-        # add the concatenated reference to a multi-fasta in the IRMA module
-        cat \${REF%.gz} >> \${irma_path}_RES/modules/\${mod}/reference/consensus.fasta
+    #----- PREPARE REFERENCE -----#
+    # Create HMM profiles
+    \${irma_path%IRMA}LABEL_RES/scripts/modelfromalign_Linux ${ref_id}_hmm -alignfile ${ref}
+    mv ${ref_id}_hmm.mod \${irma_path}_RES/modules/\${mod}/profiles/
+    # Copy the reference to the module
+    zcat ${ref} > \${irma_path}_RES/modules/\${mod}/reference/consensus.fasta
 
-        # remove the concatenated reference for easy reporting
-        rm \${REF%.gz}
-    done
-
+    #----- RUN IRMA -----#
     # run IRMA
     \$irma_path \${mod} --external-config irma.config ${reads[0]} ${reads[1]} results
 
-    # rename assemblies
-    for F in \$(ls results/*.fasta)
-    do
-        # get file name
-        FILE=\${F##*/}
-        REF_ID=\${FILE%.fasta}
-        PREFIX="${prefix}_\${REF_ID}"
+    #----- RENAME ASSEMBLY -----#
+    if [ -f "${assembly_path}" ]
+    then
+        echo ">${prefix}" > ${prefix}.fa
+        cat ${assembly_path} | grep -v '>' >> ${prefix}.fa
+        gzip ${prefix}.fa
+    fi
 
-        # return fasta
-        assembly="\${assembly_path}\${REF_ID}\${assembly_ext}"
-        echo ">\${PREFIX}" > \${PREFIX}.fa
-        cat \${assembly} | grep -v '>' >> \${PREFIX}.fa
-        gzip \${PREFIX}.fa
-    done
-
-    # clean up
-    #rm -r \${irma_path}_RES/modules/\${mod}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        IRMA: \$(IRMA | grep "(IRMA)" | cut -f 2 -d ',' | cut -f 2 -d ' ')
-    END_VERSIONS
+    # nextflow doesn't like me :(
+    echo -e "${task.process}:\\n    IRMA: \$(IRMA | grep "(IRMA)" | cut -f 2 -d ',' | cut -f 2 -d ' ')" > versions.yml
     """
 }

--- a/modules/local/ivar_consensus.nf
+++ b/modules/local/ivar_consensus.nf
@@ -27,11 +27,9 @@ process IVAR_CONSENSUS {
     samtools mpileup -aa -A -Q 0 -d 0 ${bam} | \\
        ivar consensus \\
        -p ${prefix} \\
-       -m ${params.cons_depth} \\
-       -n ${params.cons_amb} \\
-       -t ${params.cons_ratio} \\
-       -q ${params.cons_qual} \\
-       ${params.cons_drop ? '-k' : ''} \\
+       -m ${params.cons_allele_depth} \\
+       -t ${params.cons_allele_ratio} \\
+       -q ${params.cons_allele_qual} \\
        ${args}    
     sed -i 's/>.*/>${prefix}/g' ${prefix}.fa
     gzip ${prefix}.fa

--- a/nextflow.config
+++ b/nextflow.config
@@ -44,13 +44,11 @@ params {
 
     // Consensus assembly
     cons_assembler             = 'ivar'
-    cons_type                  = 'amended'
-    cons_qual                  = 20
-    cons_ratio                 = 0.60
-    cons_amb                   = 'N'
-    cons_depth                 = 10
-    cons_drop                  = false
-    cons_elong                 = false
+    cons_assembly_type         = 'consensus'
+    cons_assembly_elong        = false
+    cons_allele_qual           = 20
+    cons_allele_ratio          = 0.60
+    cons_allele_depth          = 10
     cons_condist               = 0.02
 
     // Quality Control

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -99,22 +99,25 @@
                 "ref_covplot": {
                     "type": "boolean",
                     "description": "Create reference coverage plots ('accurate' reference selection mode only)",
-                    "fa_icon": "fas fa-chart-pie"
+                    "fa_icon": "fas fa-image"
                 },
                 "ref_denovo_assembler": {
                     "type": "string",
                     "default": "megahit",
-                    "description": "De novo assembler for Shovill ('spades', 'megahit', 'velvet', 'skesa'')\""
+                    "description": "De novo assembler for Shovill ('spades', 'megahit', 'velvet', 'skesa'')\"",
+                    "fa_icon": "fas fa-puzzle-piece"
                 },
                 "ref_denovo_contigcov": {
                     "type": "integer",
                     "default": 1,
-                    "description": "Minimum depth of coverage for a contig to be retained in the de novo assembly."
+                    "description": "Minimum depth of coverage for a contig to be retained in the de novo assembly.",
+                    "fa_icon": "fas fa-align-center"
                 },
                 "ref_denovo_contiglen": {
                     "type": "integer",
                     "default": 100,
-                    "description": "Minimum length for a contig to be retained in the de novo assembly."
+                    "description": "Minimum length for a contig to be retained in the de novo assembly.",
+                    "fa_icon": "fas fa-align-justify"
                 }
             },
             "fa_icon": "fas fa-dna"
@@ -131,46 +134,40 @@
                     "description": "Consensus assembler ('irma' or 'ivar').",
                     "fa_icon": "fas fa-puzzle-piece"
                 },
-                "cons_type": {
+                "cons_assembly_type": {
                     "type": "string",
-                    "default": "default",
-                    "description": "The consensus assembly version that should be returned: 'plurality', 'amended', or 'padded' (default: 'amended'). This option only applies to IRMA (ignored by iVar).",
-                    "fa_icon": "far fa-copy"
+                    "default": "consensus",
+                    "fa_icon": "fas fa-align-justify",
+                    "description": "Method used for creating the reference-based assembly (\"consensus\", \"plurality\", \"padded\")"
                 },
-                "cons_qual": {
-                    "type": "integer",
-                    "default": 20,
-                    "description": "Minimum allele quality for consensus assembly generation.",
-                    "fa_icon": "fas fa-chart-pie"
-                },
-                "cons_ratio": {
-                    "type": "number",
-                    "default": 0.5,
-                    "description": "Minimum allele support for consensus assembly generation.",
-                    "fa_icon": "fas fa-chart-pie"
-                },
-                "cons_depth": {
-                    "type": "integer",
-                    "default": 30,
-                    "description": "Minimum allele depth for consensus assembly generation.",
-                    "fa_icon": "fas fa-chart-pie"
-                },
-                "cons_amb": {
+                "cons_assembly_elong": {
                     "type": "string",
-                    "default": "N",
-                    "fa_icon": "fas fa-chart-pie",
-                    "description": "Character used for ambiguous bases ('N', 'DEL', 'REF'). 'DEL' and 'REF' options only apply to IRMA."
-                },
-                "cons_elong": {
-                    "type": "boolean",
-                    "description": "Option to use elongation feature with IRMA. This is ignored for iVar.",
-                    "fa_icon": "fas fa-chart-pie"
+                    "fa_icon": "fas fa-arrows-alt-h",
+                    "description": "Use IRMA \"elongation\" feature."
                 },
                 "cons_condist": {
                     "type": "number",
                     "default": 0.02,
                     "fa_icon": "fas fa-chart-pie",
                     "description": "Average nucleotide difference used to condense duplicate assemblies 1-(%ANI/100). Set this to 0 if you want to skip the condense step."
+                },
+                "cons_allele_qual": {
+                    "type": "integer",
+                    "default": 20,
+                    "fa_icon": "fas fa-chart-pie",
+                    "description": "Minimum allele quality when making the reference-based assembly."
+                },
+                "cons_allele_ratio": {
+                    "type": "number",
+                    "default": 0.6,
+                    "fa_icon": "fas fa-chart-pie",
+                    "description": "Minimum allele support when making the reference-based assembly."
+                },
+                "cons_allele_depth": {
+                    "type": "integer",
+                    "default": 10,
+                    "fa_icon": "fas fa-chart-pie",
+                    "description": "Minimum allele depth when making the reference-based assembly."
                 }
             },
             "fa_icon": "fas fa-puzzle-piece"
@@ -192,31 +189,9 @@
                     "default": 0.9,
                     "description": "Minimum genome fraction used for the final quality assessment. This differs from the minimum genome fraction used for reference selection (i.e., --ref_genfrac). In general, this value should be higher than the reference selection threshold.",
                     "fa_icon": "fas fa-chart-pie"
-                } 
+                }
             },
             "fa_icon": "fas fa-chart-pie"
-        },
-        "reference_genome_options": {
-            "title": "Reference genome options",
-            "type": "object",
-            "fa_icon": "fas fa-dna",
-            "description": "Reference genome related files and options required for the workflow.",
-            "properties": {
-                "genome": {
-                    "type": "string",
-                    "description": "Name of iGenomes reference.",
-                    "fa_icon": "fas fa-book",
-                    "help_text": "If using a reference genome configured in the pipeline using iGenomes, use this parameter to give the ID for the reference. This is then used to build the full paths for all required reference genome files e.g. `--genome GRCh38`. \n\nSee the [nf-core website docs](https://nf-co.re/usage/reference_genomes) for more details.",
-                    "hidden": true
-                },
-                "igenomes_ignore": {
-                    "type": "boolean",
-                    "description": "Do not load the iGenomes reference config.",
-                    "fa_icon": "fas fa-ban",
-                    "hidden": true,
-                    "help_text": "Do not load `igenomes.config` when running the pipeline. You may choose this option if you observe clashes between custom parameters and those supplied in `igenomes.config`."
-                }
-            }
         },
         "institutional_config_options": {
             "title": "Institutional config options",
@@ -435,9 +410,6 @@
         },
         {
             "$ref": "#/definitions/assembly_options_quality_control"
-        },
-        {
-            "$ref": "#/definitions/reference_genome_options"
         },
         {
             "$ref": "#/definitions/institutional_config_options"

--- a/subworkflows/local/assemble.nf
+++ b/subworkflows/local/assemble.nf
@@ -30,26 +30,14 @@ workflow ASSEMBLE {
     if (params.cons_assembler == "irma"){
         // MODULE: Run IRMA
         IRMA (
-            ch_ref_list.groupTuple(by:0).map{ meta, ref_ids, ref_paths, reads -> [ meta, ref_paths, reads.get(0) ]},
+            ch_ref_list,
             file("${baseDir}/assets/IRMA_MODULE/", checkIfExists: true)
         )
         ch_versions = ch_versions.mix(IRMA.out.versions)
 
-        /*
-        Troubleshooting
-        */
-        IRMA
-            .out
-            .bam
-            .transpose()
-            .map{ meta, bam -> [ meta, getRefName(bam).replace(meta.id+'_', ''), bam ] }
-            .set{ ch_bam }
-        IRMA
-            .out
-            .consensus
-            .transpose()
-            .map{ meta, consensus -> [meta, getRefName(consensus).replace(meta.id+'_', ''), consensus] }
-            .set{ ch_consensus }
+        // Create consensus and bam channels
+        IRMA.out.bam.set{ ch_bam }
+        IRMA.out.consensus.set{ ch_consensus }
     }
     
     /* 

--- a/subworkflows/local/prepare.nf
+++ b/subworkflows/local/prepare.nf
@@ -56,7 +56,7 @@ workflow PREPARE {
     =============================================================================================================================
     */
     // Get all references into compressed format
-    if (! refs.toString().endsWith('.tar.gz')){
+    if (! refs.toString().endsWith('.tar.gz') ){
         // MODULE: Compress references into tar.gz file
         REFS2TAR (
             Channel


### PR DESCRIPTION
- Realized IRMA elongation was set backwards. Fixed now.
- Updated IRMA defaults to more closely match `FLU` module.
- IRMA now creates assemblies for each reference separately to avoid sharing reads between references that will be condensed at later stages.
- Updated parameters names to increased clarity and moved some defaults to the `module.config` file.