### PR TITLE
Switch to single Docker image for consistency with Singularity / Appt…

### DIFF
--- a/modules/local/format_refs.nf
+++ b/modules/local/format_refs.nf
@@ -2,9 +2,7 @@ process FORMAT_REFS {
     label 'process_low'
 
     conda "bioconda::seqtk"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/fusioncatcher-seqtk%3A1.2--hed695b0_1' :
-        'staphb/seqtk:1.3' }"
+    container 'docker.io/staphb/seqtk:1.3'
 
     input:
     path refs_tar

--- a/subworkflows/local/prepare.nf
+++ b/subworkflows/local/prepare.nf
@@ -173,12 +173,13 @@ workflow PREPARE {
 
     // Combine read channels (placeholder for long reads)
     ch_reads_short.set{ ch_reads }
+    ch_reads.view()
 
     //
     // MODULE: Run Fastp for clean read stats
     //
     FASTP_CLEAN (
-        ch_reads_short,
+        ch_reads,
         [],
         false,
         false


### PR DESCRIPTION
Switch to using 1 Docker image to ensure consistency between containerization engines. The Singularity image that was previously in use did not match the Docker image.

Close issue #14 
